### PR TITLE
[docker] Instead of mounting directories use rsync

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,13 @@
 version: 2.1
 
 defaults: &defaults
-  working_directory: /maxine-src/maxine
+  working_directory: /root/maxine-src/maxine
   docker:
     - image: beehivelab/maxine-dev:latest
   environment:
-    MAXINE_HOME: /maxine-src/maxine
-    MX_HOME: /maxine-src/mx
-    MX: "/maxine-src/mx/mx --no-download-progress --suite=maxine"
+    MAXINE_HOME: /root/maxine-src/maxine
+    MX_HOME: /root/maxine-src/mx
+    MX: "/root/maxine-src/mx/mx --no-download-progress --suite=maxine"
     MX_GIT_CACHE: refcache
 
 jobs:
@@ -28,10 +28,10 @@ jobs:
             git clone --depth 1 --branch 5.194.3 --single-branch https://github.com/graalvm/mx.git $MX_HOME
       - restore_cache:
           keys:
-            - v0-dot-mx-{{ checksum "/maxine-src/maxine/mx.maxine/suite.py"}}-gate
-            - v0-dot-mx-{{ checksum "/maxine-src/maxine/mx.maxine/suite.py"}}-image
-            - v0-dot-mx-{{ checksum "/maxine-src/maxine/mx.maxine/suite.py"}}-build
-            - v0-dot-mx-{{ checksum "/maxine-src/maxine/mx.maxine/suite.py"}}
+            - v0-dot-mx-{{ checksum "/root/maxine-src/maxine/mx.maxine/suite.py"}}-gate
+            - v0-dot-mx-{{ checksum "/root/maxine-src/maxine/mx.maxine/suite.py"}}-image
+            - v0-dot-mx-{{ checksum "/root/maxine-src/maxine/mx.maxine/suite.py"}}-build
+            - v0-dot-mx-{{ checksum "/root/maxine-src/maxine/mx.maxine/suite.py"}}
       - run:
           name: "Checkstyle"
           command: $MX checkstyle
@@ -46,17 +46,17 @@ jobs:
       - save_cache:
           key: v0-maxine-{{ .Environment.CIRCLE_SHA1 }}
           paths:
-            - /maxine-src/maxine
+            - /root/maxine-src/maxine
       - save_cache:
           key: v0-maxine-graal-{{ .Environment.CIRCLE_SHA1 }}
           paths:
-            - /maxine-src/Maxine-Graal
+            - /root/maxine-src/Maxine-Graal
       - save_cache:
           key: v0-mx-{{ .Environment.CIRCLE_SHA1 }}
           paths:
-            - /maxine-src/mx
+            - /root/maxine-src/mx
       - save_cache:
-          key: v0-dot-mx-{{ checksum "/maxine-src/maxine/mx.maxine/suite.py"}}-build
+          key: v0-dot-mx-{{ checksum "/root/maxine-src/maxine/mx.maxine/suite.py"}}-build
           paths:
             - /root/.mx
   crossisa-aarch64:
@@ -70,16 +70,16 @@ jobs:
           key: v0-mx-{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
           keys:
-            - v0-dot-mx-{{ checksum "/maxine-src/maxine/mx.maxine/suite.py"}}-gate
-            - v0-dot-mx-{{ checksum "/maxine-src/maxine/mx.maxine/suite.py"}}-image
-            - v0-dot-mx-{{ checksum "/maxine-src/maxine/mx.maxine/suite.py"}}-build
-            - v0-dot-mx-{{ checksum "/maxine-src/maxine/mx.maxine/suite.py"}}
+            - v0-dot-mx-{{ checksum "/root/maxine-src/maxine/mx.maxine/suite.py"}}-gate
+            - v0-dot-mx-{{ checksum "/root/maxine-src/maxine/mx.maxine/suite.py"}}-image
+            - v0-dot-mx-{{ checksum "/root/maxine-src/maxine/mx.maxine/suite.py"}}-build
+            - v0-dot-mx-{{ checksum "/root/maxine-src/maxine/mx.maxine/suite.py"}}
       - run:
           name: "Cross-ISA testing"
           no_output_timeout: 30m
           command: $MX --J @"-Dmax.platform=linux-aarch64 -Dtest.crossisa.qemu=1 -ea" testme -s=t -junit-test-timeout=1800 -tests=junit:aarch64.asm+Aarch64T1XTest+Aarch64T1XpTest+Aarch64JTT
       - store_artifacts:
-          path: /maxine-src/maxine/maxine-tester
+          path: /root/maxine-src/maxine/maxine-tester
           destination: crossisa-aarch64
   crossisa-armv7:
     <<: *defaults
@@ -92,16 +92,16 @@ jobs:
           key: v0-mx-{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
           keys:
-            - v0-dot-mx-{{ checksum "/maxine-src/maxine/mx.maxine/suite.py"}}-gate
-            - v0-dot-mx-{{ checksum "/maxine-src/maxine/mx.maxine/suite.py"}}-image
-            - v0-dot-mx-{{ checksum "/maxine-src/maxine/mx.maxine/suite.py"}}-build
-            - v0-dot-mx-{{ checksum "/maxine-src/maxine/mx.maxine/suite.py"}}
+            - v0-dot-mx-{{ checksum "/root/maxine-src/maxine/mx.maxine/suite.py"}}-gate
+            - v0-dot-mx-{{ checksum "/root/maxine-src/maxine/mx.maxine/suite.py"}}-image
+            - v0-dot-mx-{{ checksum "/root/maxine-src/maxine/mx.maxine/suite.py"}}-build
+            - v0-dot-mx-{{ checksum "/root/maxine-src/maxine/mx.maxine/suite.py"}}
       - run:
           name: "Cross-ISA testing"
           no_output_timeout: 30m
           command: $MX --J @"-Dmax.platform=linux-arm -Dtest.crossisa.qemu=1 -ea" testme -s=t -junit-test-timeout=1800 -tests=junit:armv7.asm+ARMV7T1XTest+ARMV7JTT
       - store_artifacts:
-          path: /maxine-src/maxine/maxine-tester
+          path: /root/maxine-src/maxine/maxine-tester
           destination: crossisa-armv7
   crossisa-riscv:
     <<: *defaults
@@ -114,16 +114,16 @@ jobs:
           key: v0-mx-{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
           keys:
-            - v0-dot-mx-{{ checksum "/maxine-src/maxine/mx.maxine/suite.py"}}-gate
-            - v0-dot-mx-{{ checksum "/maxine-src/maxine/mx.maxine/suite.py"}}-image
-            - v0-dot-mx-{{ checksum "/maxine-src/maxine/mx.maxine/suite.py"}}-build
-            - v0-dot-mx-{{ checksum "/maxine-src/maxine/mx.maxine/suite.py"}}
+            - v0-dot-mx-{{ checksum "/root/maxine-src/maxine/mx.maxine/suite.py"}}-gate
+            - v0-dot-mx-{{ checksum "/root/maxine-src/maxine/mx.maxine/suite.py"}}-image
+            - v0-dot-mx-{{ checksum "/root/maxine-src/maxine/mx.maxine/suite.py"}}-build
+            - v0-dot-mx-{{ checksum "/root/maxine-src/maxine/mx.maxine/suite.py"}}
       - run:
           name: "Cross-ISA testing"
           no_output_timeout: 30m
           command: $MX --J @"-Dmax.platform=linux-riscv64 -Dtest.crossisa.qemu=1 -ea" testme -s=t -tests=junit:riscv64.asm+max.asm.target.riscv+riscv64.t1x+riscv64.jtt
       - store_artifacts:
-          path: /maxine-src/maxine/maxine-tester
+          path: /root/maxine-src/maxine/maxine-tester
           destination: crossisa-riscv
   image:
     <<: *defaults
@@ -136,10 +136,10 @@ jobs:
           key: v0-mx-{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
           keys:
-            - v0-dot-mx-{{ checksum "/maxine-src/maxine/mx.maxine/suite.py"}}-gate
-            - v0-dot-mx-{{ checksum "/maxine-src/maxine/mx.maxine/suite.py"}}-image
-            - v0-dot-mx-{{ checksum "/maxine-src/maxine/mx.maxine/suite.py"}}-build
-            - v0-dot-mx-{{ checksum "/maxine-src/maxine/mx.maxine/suite.py"}}
+            - v0-dot-mx-{{ checksum "/root/maxine-src/maxine/mx.maxine/suite.py"}}-gate
+            - v0-dot-mx-{{ checksum "/root/maxine-src/maxine/mx.maxine/suite.py"}}-image
+            - v0-dot-mx-{{ checksum "/root/maxine-src/maxine/mx.maxine/suite.py"}}-build
+            - v0-dot-mx-{{ checksum "/root/maxine-src/maxine/mx.maxine/suite.py"}}
       - run:
           name: "build boot images"
           command: |
@@ -150,9 +150,9 @@ jobs:
       - save_cache:
           key: v0-image-{{ .Environment.CIRCLE_SHA1 }}
           paths:
-            - /maxine-src/maxine
+            - /root/maxine-src/maxine
       - save_cache:
-          key: v0-dot-mx-{{ checksum "/maxine-src/maxine/mx.maxine/suite.py"}}-image
+          key: v0-dot-mx-{{ checksum "/root/maxine-src/maxine/mx.maxine/suite.py"}}-image
           paths:
             - /root/.mx
   gate:
@@ -166,19 +166,19 @@ jobs:
           key: v0-mx-{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
           keys:
-            - v0-dot-mx-{{ checksum "/maxine-src/maxine/mx.maxine/suite.py"}}-gate
-            - v0-dot-mx-{{ checksum "/maxine-src/maxine/mx.maxine/suite.py"}}-image
-            - v0-dot-mx-{{ checksum "/maxine-src/maxine/mx.maxine/suite.py"}}-build
-            - v0-dot-mx-{{ checksum "/maxine-src/maxine/mx.maxine/suite.py"}}
+            - v0-dot-mx-{{ checksum "/root/maxine-src/maxine/mx.maxine/suite.py"}}-gate
+            - v0-dot-mx-{{ checksum "/root/maxine-src/maxine/mx.maxine/suite.py"}}-image
+            - v0-dot-mx-{{ checksum "/root/maxine-src/maxine/mx.maxine/suite.py"}}-build
+            - v0-dot-mx-{{ checksum "/root/maxine-src/maxine/mx.maxine/suite.py"}}
       - run:
           name: "mx gate -nocheck"
           command: $MX -J-Xmx1g gate -maxvm-args=-Xmx1g -refvm-args=-Xmx1g
       - save_cache:
-          key: v0-dot-mx-{{ checksum "/maxine-src/maxine/mx.maxine/suite.py"}}-gate
+          key: v0-dot-mx-{{ checksum "/root/maxine-src/maxine/mx.maxine/suite.py"}}-gate
           paths:
             - /root/.mx
       - store_artifacts:
-          path: /maxine-src/maxine/maxine-tester
+          path: /root/maxine-src/maxine/maxine-tester
           destination: gate
 
 workflows:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
         dockerfile {
             filename 'Dockerfile'
             dir 'docker'
-            args '--mount src="$HOME/.mx",target="/.mx",type=bind'
+            args '--mount src="$HOME/.mx",target="/root/.mx",type=bind'
         }
     }
     options {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     make gcc gdb g++ python python2.7 git \
     openjdk-8-jdk \
-    screen \
+    screen rsync \
     && apt-get clean
 
 # Cross-ISA support
@@ -59,7 +59,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends linux-tools-generic \
     && apt-get clean
 
-ENV MAXINE_SRC=/maxine-src
+ENV MAXINE_SRC=/root/maxine-src
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
 ENV MAXINE_HOME=$MAXINE_SRC/maxine
 ENV DEFAULT_VM=maxine
@@ -68,6 +68,14 @@ ENV PATH=$PATH:/opt/riscv/bin:$MAXINE_SRC/mx/:$MAXINE_HOME/com.oracle.max.vm.nat
 # You will need to download and install SPECJVM2008 manually to the following directory
 # ENV SPECJVM2008=$MAXINE_SRC/graal/lib/SPECJVM2008
 
+# enable rsync
+RUN sed -i 's/RSYNC_ENABLE=false/RSYNC_ENABLE=true/g' /etc/default/rsync
+# Setup rsync
+ADD ./rsyncd.conf /etc/rsyncd.conf
+
+RUN mkdir /root/.mx
+RUN mkdir -p ${MAXINE_HOME}
+
 WORKDIR $MAXINE_HOME
 
-CMD bash
+CMD service rsync start && bash

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,27 @@
 # Running maxineVM in docker
 
-## Prerequisites
+## Creating the docker container
+
+From the directory `maxine-src` (created in [Prerequisites](#prerequisites)) run:
+
+```
+docker create \
+    -p 9873:873 \
+    --mount src="/tmp/.X11-unix",target="/tmp/.X11-unix",type=bind \
+    -e DISPLAY=unix$DISPLAY --cap-add=SYS_PTRACE \
+    --name maxine-dev -ti beehivelab/maxine-dev
+```
+
+This will create a container named `maxine-dev`.
+
+- `-p 9873:873` maps port 9873 of the host to port 873 of the docker container.
+- `--mount src="/tmp/.X11-unix",target="/tmp/.X11-unix",type=bind` mounts the host X11 socket to the container socket.
+- `-e DISPLAY=unix$DISPLAY` passes in the `DISPLAY` environment variable.
+- `--cap-add=SYS_PTRACE` enables `ptrace` capability for the container.
+- `--name maxine-dev` names the new image so that it can later be referenced (to start it, stop it, attach to it etc.).
+- `-ti` instructs docker to create an interactive session with a pseudo-tty, to allow us to interact with the container.
+
+## Initializing the container
 
 The docker image expects the source code to be in the layout shown below:
 
@@ -19,30 +40,19 @@ $ git clone https://github.com/graalvm/mx.git maxine-src/mx
 $ git clone https://github.com/beehive-lab/Maxine-VM.git maxine-src/maxine
 ```
 
-## Creating the docker container
-
-From the directory `maxine-src` (created in [Prerequisites](#prerequisites)) run:
+Then copy the `maxine-src` directory to the container using:
 
 ```
-docker create -u=$(id -u):$(id -g) \
-    --mount src="$(pwd)",target="/maxine-src",type=bind \
-    --mount src="$HOME/.mx",target="/.mx",type=bind \
-    --mount src="/tmp/.X11-unix",target="/tmp/.X11-unix",type=bind \
-    -e DISPLAY=unix$DISPLAY --cap-add=SYS_PTRACE \
-    --name maxine-dev -ti beehivelab/maxine-dev
+$ rsync -avP maxine-src --delete rsync://localhost:9873/maxine-src/
 ```
 
-This will create a container named `maxine-dev`.
+### Optionally copy over your `~/.mx` directory
 
-- `-u=$(id -u):$(id -g)` instructs docker to write and read files as the current user instead of root which is the default.
-- `--mount src="$(pwd)",target="/maxine-src",type=bind` essentially mounts the current directory to the docker container under the `/maxine-src` directory.
-  Similarly, `--mount src="$HOME/.mx",target="/.mx",type=bind` does the same for the `~/.mx` directory.
-  Any changes performed to mounted folders outside the docker container are visible in the container and vice versa.
-- `--mount src="/tmp/.X11-unix",target="/tmp/.X11-unix",type=bind` mounts the host X11 socket to the container socket.
-- `-e DISPLAY=unix$DISPLAY` passes in the `DISPLAY` environment variable.
-- `--cap-add=SYS_PTRACE` enables `ptrace` capability for the container.
-- `--name maxine-dev` names the new image so that it can later be referenced (to start it, stop it, attach to it etc.).
-- `-ti` instructs docker to create an interactive session with a pseudo-tty, to allow us to interact with the container.
+If you use `mx` locally as well you can use the same cache to avoid fetching again large files:
+
+```
+$ rsync -avP ~/.mx --delete rsync://localhost:9873/mx/
+```
 
 ## Using the docker container
 
@@ -56,6 +66,15 @@ This will start the container and open a `bash` shell in it.
 From this shell you can build and run maxine.
 
 To exit the shell and stop the container type `Ctrl-D`.
+
+## Keeping your data on the host in sync with your data on the docker container
+
+If you use the container for development purposes you most probably will be interested in editing the source code locally and building and running on the docker container.
+To automatically synchronize your files from the host to the container use:
+
+```
+fswatch -0 maxine-src | xargs -0 -n 1 -I {} rsync -avP maxine-src --delete rsync://localhost:9873/maxine-src/
+```
 
 ## Build the docker image
 

--- a/docker/rsyncd.conf
+++ b/docker/rsyncd.conf
@@ -1,0 +1,8 @@
+[root]
+path = /root/
+# hosts you allow to access
+hosts allow = *
+list = true
+uid = root
+gid = root
+read only = false


### PR DESCRIPTION
Mounting host directories to containers and compiling from the container
appears to be very slow on MacOS (on Windows the overhead is less but
still noteable).  Using rsync to transfer only changes to the container
and then using the files "natively" in the container is much faster and
can be automated using fswatch.

Additionally not having to mount directories, we no longer need to use
the uid and gid of the host user, allowing us to use the root user as is
standard in docker.